### PR TITLE
add 'Content-Length' => '0', to getHeaders

### DIFF
--- a/source/requests/LegacyApiRequest.php
+++ b/source/requests/LegacyApiRequest.php
@@ -379,6 +379,7 @@ class LegacyApiRequest extends AbstractRequest implements Request, GroupManageme
         return [
             'Authorization' => 'key='.$this->getServerKey(),
             'Content-Type' => 'application/json',
+            'Content-Length' => '0',
             'project_id' => $this->getSenderId(),
         ];
     }


### PR DESCRIPTION
We ned add  'Content-Length' => '0' for escape error 411 on FCM.